### PR TITLE
Updated & added dependencies for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,17 +36,22 @@
   	<dependency>
   		<groupId>com.amazonaws</groupId>
   		<artifactId>aws-lambda-java-core</artifactId>
-  		<version>1.1.0</version>
+  		<version>1.2.1</version>
   	</dependency>
-  	  	<dependency>
+  	<dependency>
   		<groupId>com.amazonaws</groupId>
   		<artifactId>aws-lambda-java-events</artifactId>
-  		<version>1.1.0</version>
+  		<version>2.2.9</version>
   	</dependency>
+    <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-s3</artifactId>
+        <version>1.12.57</version>
+    </dependency>
   	<dependency>
    		<groupId>commons-io</groupId>
    		<artifactId>commons-io</artifactId>
-   		<version>2.7</version>
+   		<version>2.11.0</version>
    	</dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This is my first PR, go easy on me.

I've updated and added some dependencies in the POM file. The compile works and the code runs fine on Lambda using Java 11.

There are some warnings when the process is compiled. I wasn't sure what to do with these.

```bash
[WARNING] jackson-dataformat-cbor-2.12.3.jar, jackson-annotations-2.12.3.jar, jackson-core-2.12.3.jar, jackson-databind-2.12.3.jar define 1 overlapping classes: 
[WARNING]   - module-info
[WARNING] maven-shade-plugin has detected that some class files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the class is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See http://docs.codehaus.org/display/MAVENUSER/Shade+Plugin
``` 